### PR TITLE
Add flag to specify term

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -240,11 +240,11 @@ impl Api {
             .term)
     }
 
-    pub async fn modules(&self, current_term_only: bool) -> Result<Vec<Module>> {
-        let current_term = if current_term_only {
-            Some(self.current_term().await?)
+    pub async fn modules(&self, term: Option<String>) -> Result<Vec<Module>> {
+        let specified_term = if let Some(specified_term) = term {
+            specified_term
         } else {
-            None
+            self.current_term().await?
         };
 
         let modules = self
@@ -252,14 +252,10 @@ impl Api {
             .await?;
 
         if let Data::Modules(modules) = modules.data {
-            if let Some(current_term) = current_term {
-                Ok(modules
-                    .into_iter()
-                    .filter(|m| m.term == current_term)
-                    .collect())
-            } else {
-                Ok(modules)
-            }
+            Ok(modules
+                .into_iter()
+                .filter(|m| m.term == specified_term)
+                .collect())
         } else if let Data::Empty(_) = modules.data {
             Ok(vec![])
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,13 @@ async fn main() -> Result<()> {
                 .number_of_values(1)
                 .default_value("skip"),
         )
+        .arg(
+            Arg::with_name("term")
+                .long("term")
+                .takes_value(true)
+                .value_name("term")
+                .number_of_values(1),
+        )
         .get_matches();
     let credential_file = matches
         .value_of("credential-file")
@@ -320,6 +327,13 @@ async fn main() -> Result<()> {
             _ => panic!("Unable to parse parameter of overwrite_mode"),
         })
         .unwrap_or(OverwriteMode::Skip);
+    let specified_term = matches.value_of("term").map(|s| {
+        if s.len() == 4 && s.chars().all(char::is_numeric) {
+            s.to_owned()
+        } else {
+            panic!("Invalid input term")
+        }
+    });
 
     let (username, password) =
         get_credentials(&credential_file).expect("Unable to get credentials");
@@ -334,7 +348,7 @@ async fn main() -> Result<()> {
 
     let name = api.name().await?;
     println!("Hi {}!", name);
-    let modules = api.modules(true).await?;
+    let modules = api.modules(specified_term).await?;
     println!("You are taking:");
     for module in modules.iter().filter(|m| m.is_taking()) {
         println!("- {} {}", module.code, module.name);


### PR DESCRIPTION
Closes #617. The program now only accesses modules of the current term/semester indicated by `Api::current_term`, unless specified by the `--term` flag. 

I believe Julius wanted to implement something like this anyways, as `Api::modules` was taking in a `current_term` boolean, but there's no flag that sets this boolean value.

This PR contains changes in #616.