### PR TITLE
Fix #639: Append id to duplicate files with the same path

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -112,15 +112,9 @@ async fn load_modules_files(
                 )
                 .await
                 .map(|mut files| {
-                    // this map() is a (temporary) fix for #639 to avoid file corruption;
-                    // we keep only the last updated file if multiple files have the same name
-                    files.sort_unstable_by(|file1, file2| {
-                        file1
-                            .path()
-                            .cmp(file2.path())
-                            .then_with(|| file1.last_updated().cmp(&file2.last_updated()).reverse())
-                    });
-                    files.dedup_by(|file1, file2| file1.path() == file2.path());
+                    // to avoid duplicate files from being corrupted,
+                    // we append the id to duplicate files
+                    fluminurs::file::sort_and_make_all_paths_unique(&mut files);
                     files
                 })
         },

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -165,10 +166,6 @@ impl Resource for File {
 }
 
 impl File {
-    pub fn last_updated(&self) -> SystemTime {
-        self.last_updated
-    }
-
     pub async fn get_download_url(&self, api: &Api) -> Result<Url> {
         let data = api
             .api_as_json::<ApiData<String>>(
@@ -210,4 +207,35 @@ impl File {
         }
         Ok(())
     }
+}
+
+// Makes the paths of all the given files unique, based on the last updated time and the id.
+// This function will also sort the files.
+pub fn sort_and_make_all_paths_unique(files: &mut [File]) {
+    files.sort_unstable_by(|file1, file2| {
+        file1
+            .path
+            .cmp(&file2.path)
+            .then_with(|| file1.last_updated.cmp(&file2.last_updated).reverse())
+    });
+    files.iter_mut().fold(Path::new(""), |path, file| {
+        if path == file.path {
+            file.path.set_file_name({
+                let mut new_name = file.path.file_stem().map_or_else(OsString::new, |n| {
+                    let mut new_name = n.to_owned();
+                    new_name.push("-");
+                    new_name
+                });
+                new_name.push(&file.id);
+                file.path.extension().map(|e| {
+                    new_name.push(".");
+                    new_name.push(e);
+                });
+                new_name
+            });
+            path
+        } else {
+            file.path.as_ref()
+        }
+    });
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -165,6 +165,10 @@ impl Resource for File {
 }
 
 impl File {
+    pub fn last_updated(&self) -> SystemTime {
+        self.last_updated
+    }
+
     pub async fn get_download_url(&self, api: &Api) -> Result<Url> {
         let data = api
             .api_as_json::<ApiData<String>>(


### PR DESCRIPTION
- This is a temporary fix that isn't ideal, but definitely better than what we have now.