### PR TITLE
Add Windows manifest to enable long paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "winres",
 ]
 
 [[package]]
@@ -1683,6 +1684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1928,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4fb510bbfe5b8992ff15f77a2e6fe6cf062878f0eda00c0f44963a807ca5dc"
+dependencies = [
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1.5", features = ["full"] }
+
+[build-dependencies]
+winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+use winres;
+
+fn main() -> std::io::Result<()> {
+    if cfg!(target_os = "windows") {
+        // We need to set the 'longPathAware' manifest key, so that file paths with length >260 chars will work.
+        // This happens sometimes since we encode IDs for duplicate files.
+        let mut res = winres::WindowsResource::new();
+        res.set_manifest(
+            r#"<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+</application>
+</assembly>"#);
+        res.compile()?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
While we could have used a target-specific build dependency, it confuses Cargo.lock.  So for now we force all OSes to download the winres crate (but the stuff in the crate should probably be no-ops on non-Windows).  Resolves #646 to the extent where possible.  Users still need to opt-in to the new behaviour by setting a registry key (https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).