### PR TITLE
Minor changes to make fluminurs more async-friendly

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -31,6 +31,7 @@ pub struct DirectoryHandle {
     /* last_updated: SystemTime, */
 }
 
+#[derive(Debug, Clone)]
 pub struct File {
     id: String,
     path: PathBuf,
@@ -149,7 +150,7 @@ impl DirectoryHandle {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SimpleDownloadableResource for File {
     fn id(&self) -> &str {
         &self.id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ async fn auth_http_post(
     .await
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Api {
     jwt: String,
     client: Client,

--- a/src/module.rs
+++ b/src/module.rs
@@ -10,7 +10,7 @@ use crate::util::sanitise_filename;
 use crate::weblecture::WebLectureHandle;
 use crate::{Api, ApiData, Result};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct Access {
     #[serde(rename = "access_Full")]
     full: bool,
@@ -34,7 +34,7 @@ pub struct Announcement {
     pub description: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Module {
     pub id: String,
     #[serde(rename = "name")]

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use reqwest::Method;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::conferencing::ConferencingHandle;
 use crate::file::DirectoryHandle;
@@ -10,7 +10,7 @@ use crate::util::sanitise_filename;
 use crate::weblecture::WebLectureHandle;
 use crate::{Api, ApiData, Result};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct Access {
     #[serde(rename = "access_Full")]
     full: bool,
@@ -34,7 +34,7 @@ pub struct Announcement {
     pub description: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Module {
     pub id: String,
     #[serde(rename = "name")]

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use reqwest::Method;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::conferencing::ConferencingHandle;
 use crate::file::DirectoryHandle;
@@ -10,7 +10,7 @@ use crate::util::sanitise_filename;
 use crate::weblecture::WebLectureHandle;
 use crate::{Api, ApiData, Result};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 struct Access {
     #[serde(rename = "access_Full")]
     full: bool,
@@ -34,7 +34,7 @@ pub struct Announcement {
     pub description: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Module {
     pub id: String,
     #[serde(rename = "name")]

--- a/src/multimedia/external_multimedia.rs
+++ b/src/multimedia/external_multimedia.rs
@@ -46,6 +46,7 @@ struct ExternalMultimediaRequestQueryParameters {
     pub folder_id: String,
 }
 
+#[derive(Debug, Clone)]
 pub struct ExternalVideo {
     id: String,
     path: PathBuf,
@@ -121,7 +122,7 @@ pub(super) async fn load_external_channel(
         .collect::<Vec<_>>())
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Resource for ExternalVideo {
     fn id(&self) -> &str {
         &self.id

--- a/src/multimedia/mod.rs
+++ b/src/multimedia/mod.rs
@@ -90,7 +90,7 @@ impl MultimediaHandle {
                 }
                 Ok((internal_videos, external_videos))
             }
-            None => Err("Invalid API response from server: type mismatch"),
+            None => Ok((vec![], vec![])),
         }
     }
 

--- a/src/multimedia/mod.rs
+++ b/src/multimedia/mod.rs
@@ -38,6 +38,7 @@ pub struct MultimediaHandle {
     path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
 pub struct InternalVideo {
     id: String,
     stream_url_path: String,
@@ -128,7 +129,7 @@ fn make_mp4_extension(path: &Path) -> PathBuf {
     path.with_extension("mp4")
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Resource for InternalVideo {
     fn id(&self) -> &str {
         &self.id

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::marker::Sync;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -9,7 +10,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::{Api, Error, Result};
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait Resource {
     fn id(&self) -> &str;
     fn path(&self) -> &Path;
@@ -24,7 +25,7 @@ pub trait Resource {
     ) -> Result<OverwriteResult>;
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait SimpleDownloadableResource {
     fn id(&self) -> &str;
     fn path(&self) -> &Path;
@@ -33,8 +34,8 @@ pub trait SimpleDownloadableResource {
     async fn get_download_url(&self, api: &Api) -> Result<Url>;
 }
 
-#[async_trait(?Send)]
-impl<T: SimpleDownloadableResource> Resource for T {
+#[async_trait]
+impl<T: SimpleDownloadableResource + Sync> Resource for T {
     fn id(&self) -> &str {
         self.id()
     }
@@ -108,6 +109,7 @@ pub enum OverwriteMode {
     Rename,
 }
 
+#[derive(Clone)]
 pub enum OverwriteResult {
     NewFile,
     AlreadyHave,

--- a/src/weblecture.rs
+++ b/src/weblecture.rs
@@ -31,6 +31,7 @@ pub struct WebLectureHandle {
     path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
 pub struct WebLectureVideo {
     module_id: String,
     id: String,
@@ -88,7 +89,7 @@ impl WebLectureHandle {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Resource for WebLectureVideo {
     fn id(&self) -> &str {
         &self.id


### PR DESCRIPTION
I'm currently working on a Rust-based, cross-platform desktop client based on fluminurs (currently named, rather unsurprisingly, [fluminurs-desktop](https://github.com/bnjmnt4n/fluminurs-desktop)) using [iced](https://github.com/hecrj/iced).

This PR upstreams a couple of changes I made to my fork of fluminurs.

Iced has the notion of Commands which allow futures to be polled in a separate thread to prevent blocking in the UI thread. However, this requires the futures to have to implement `Send` to be passed across thread boundaries. This PR modifies the relevant async traits to return futures which are `Send`.

I also modified some of the internal resource types to implement `Clone`, to allow them to be cloned and passed across thread boundaries as well.