### PR TITLE
Modify multimedia retrieval to use same parameters as frontend

### DIFF
--- a/src/multimedia/mod.rs
+++ b/src/multimedia/mod.rs
@@ -59,7 +59,7 @@ impl MultimediaHandle {
     pub async fn load(self, api: &Api) -> Result<(Vec<InternalVideo>, Vec<ExternalVideo>)> {
         let multimedia_resp = api
             .api_as_json::<ApiData<Vec<Channel>>>(
-                &format!("multimedia/?ParentID={}", self.id),
+                &format!("multimedia/?populate=contentSummary&ParentID={}", self.id),
                 Method::GET,
                 None,
             )


### PR DESCRIPTION
Fixes errors caused by luminus returning extra channels when queried `api/multimedia`. 

Closes #655 