### PR TITLE
Stream external multimedia videos since there is no longer a direct download link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "fluminurs"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "ammonia",
  "async-trait",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod module;
 pub mod multimedia;
 pub mod panopto;
 pub mod resource;
+pub mod streamer;
 pub mod util;
 pub mod weblecture;
 

--- a/src/multimedia/external_multimedia.rs
+++ b/src/multimedia/external_multimedia.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -10,7 +9,7 @@ use crate::multimedia::Channel;
 use crate::panopto;
 use crate::resource;
 use crate::resource::{OverwriteMode, OverwriteResult, Resource};
-use crate::streamer::stream_video;
+use crate::streamer::stream_and_mux_videos;
 use crate::util::sanitise_filename;
 use crate::{Api, Result};
 
@@ -154,70 +153,11 @@ impl Resource for ExternalVideo {
             temp_destination,
             overwrite,
             self.last_updated(),
-            move |api| get_stream_url_path(api, delivery_id),
-            move |api, stream_url_path, temp_destination| async move {
-                stream_video(api, &stream_url_path, temp_destination).await
+            move |api| panopto::get_stream_specs(api, delivery_id),
+            move |api, stream_specs, temp_destination| async move {
+                stream_and_mux_videos(api, &stream_specs, temp_destination).await
             },
         )
         .await
     }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct DeliveryInfo {
-    delivery: Delivery,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct Delivery {
-    streams: Vec<Stream>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct Stream {
-    stream_url: String,
-}
-
-async fn get_stream_url_path(api: &Api, delivery_id: &str) -> Result<String> {
-    let post_data = make_deliver_info_post_data(delivery_id);
-    let delivery_info = api
-        .custom_request(
-            Url::parse("https://mediaweb.ap.panopto.com/Panopto/Pages/Viewer/DeliveryInfo.aspx")
-                .expect("Unable to parse Panopto DeliverInfo URL"),
-            Method::POST,
-            Some(&post_data),
-            Api::add_desktop_user_agent,
-        )
-        .await?
-        .json::<DeliveryInfo>()
-        .await
-        .map_err(|_| "Unable to deserialize JSON")?;
-
-    let mut delivery = delivery_info.delivery;
-    if delivery.streams.len() != 1 {
-        Err("Expected exactly one stream in external multimedia")
-    } else {
-        Ok(delivery.streams.pop().unwrap().stream_url)
-    }
-}
-
-/// Constructs the form params required for the post request to DeliveryInfo.aspx
-fn make_deliver_info_post_data(delivery_id: &str) -> HashMap<&str, &str> {
-    // These params are used by Panopto's web frontend,
-    // so we'll mimic all of it.  Not sure if there are any videos
-    // that need different selections of these params.
-    let mut post_data: HashMap<&str, &str> = HashMap::new();
-    post_data.insert("deliveryId", delivery_id);
-    post_data.insert("invocationId", "");
-    post_data.insert("isLiveNotes", "false");
-    post_data.insert("refreshAuthCookie", "true");
-    post_data.insert("isActiveBroadcast", "false");
-    post_data.insert("isEditing", "false");
-    post_data.insert("isKollectiveAgentInstalled", "false");
-    post_data.insert("isEmbed", "false");
-    post_data.insert("responseType", "json");
-    post_data
 }

--- a/src/panopto.rs
+++ b/src/panopto.rs
@@ -3,9 +3,9 @@
 use std::collections::HashMap;
 
 use reqwest::{Method, Response, Url};
-use scraper::{Html, Selector};
 use serde::Deserialize;
 
+use crate::streamer::StreamSpec;
 use crate::{Api, Result};
 
 #[derive(Debug, Deserialize)]
@@ -42,16 +42,69 @@ pub async fn launch(api: &Api, api_path: &str) -> Result<Response> {
         .await
 }
 
-// This function probably doesn't work any more and weblectures is probably broken as a result
-pub fn extract_video_url_from_document(html: &str) -> Result<Url> {
-    let document = Html::parse_document(html);
-    let selector = Selector::parse(r#"meta[property="og:video"]"#).unwrap();
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DeliveryInfo {
+    delivery: Delivery,
+}
 
-    let url_str = document
-        .select(&selector)
-        .next()
-        .and_then(|element| element.value().attr("content"))
-        .ok_or("Unable to find video URL")?;
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Delivery {
+    streams: Vec<Stream>,
+}
 
-    Url::parse(url_str).map_err(|_| "Unable to parse video URL")
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Stream {
+    relative_start: f64,
+    stream_url: String,
+}
+
+pub async fn get_stream_specs(api: &Api, delivery_id: &str) -> Result<Vec<StreamSpec>> {
+    let post_data = make_delivery_info_post_data(delivery_id);
+    let delivery_info = api
+        .custom_request(
+            Url::parse("https://mediaweb.ap.panopto.com/Panopto/Pages/Viewer/DeliveryInfo.aspx")
+                .expect("Unable to parse Panopto DeliverInfo URL"),
+            Method::POST,
+            Some(&post_data),
+            Api::add_desktop_user_agent,
+        )
+        .await?
+        .json::<DeliveryInfo>()
+        .await
+        .map_err(|_| "Unable to deserialize JSON")?;
+
+    let streams = delivery_info.delivery.streams;
+
+    if streams.is_empty() {
+        Err("No streams available on DeliveryInfo")
+    } else {
+        Ok(streams
+            .into_iter()
+            .map(|s| StreamSpec {
+                stream_url_path: s.stream_url,
+                offset_seconds: s.relative_start,
+            })
+            .collect())
+    }
+}
+
+/// Constructs the form params required for the post request to DeliveryInfo.aspx
+fn make_delivery_info_post_data(delivery_id: &str) -> HashMap<&str, &str> {
+    // These params are used by Panopto's web frontend,
+    // so we'll mimic all of it.  Not sure if there are any videos
+    // that need different selections of these params.
+    let mut post_data: HashMap<&str, &str> = HashMap::new();
+    post_data.insert("deliveryId", delivery_id);
+    post_data.insert("invocationId", "");
+    post_data.insert("isLiveNotes", "false");
+    post_data.insert("refreshAuthCookie", "true");
+    post_data.insert("isActiveBroadcast", "false");
+    post_data.insert("isEditing", "false");
+    post_data.insert("isKollectiveAgentInstalled", "false");
+    post_data.insert("isEmbed", "false");
+    post_data.insert("responseType", "json");
+    post_data
 }

--- a/src/panopto.rs
+++ b/src/panopto.rs
@@ -42,6 +42,7 @@ pub async fn launch(api: &Api, api_path: &str) -> Result<Response> {
         .await
 }
 
+// This function probably doesn't work any more and weblectures is probably broken as a result
 pub fn extract_video_url_from_document(html: &str) -> Result<Url> {
     let document = Html::parse_document(html);
     let selector = Selector::parse(r#"meta[property="og:video"]"#).unwrap();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -116,6 +116,7 @@ pub enum OverwriteResult {
     Renamed { renamed_path: PathBuf },
 }
 
+#[derive(Copy, Clone)]
 pub enum RetryableError {
     Retry(Error),
     Fail(Error),

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -1,6 +1,7 @@
 use crate::resource::{RetryableError, RetryableResult};
 use crate::Api;
-use std::path::Path;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
 /// Uses ffmpeg to stream a given m3u8 video file.
@@ -33,28 +34,87 @@ pub async fn stream_and_mux_videos(
     streams: &[StreamSpec],
     temp_destination: &Path,
 ) -> RetryableResult<()> {
+    assert!(!streams.is_empty());
     if streams.len() == 1 {
         // if there's only one video, we should ignore the offset
         stream_video(api, &streams[0].stream_url_path, temp_destination).await
     } else {
+        // we have multiple videos, we have to stream each of them to separate temporary files, then mux them together
+        // the reason why we need temp files is here:
+        // https://stackoverflow.com/questions/68890149/download-multiple-files-with-ffmpeg-keep-one-stream-from-each-according-to-def
+
+        // generate the temp file names
+        let temp_stream_dests: Vec<PathBuf> = (0..streams.len())
+            .map(|i| make_temp_stream_file_name(temp_destination, i))
+            .collect();
+
+        // stream the streams to the temp files
+        let stream_results: Vec<RetryableResult<()>> = futures_util::future::join_all(
+            streams
+                .iter()
+                .zip(temp_stream_dests.iter())
+                .map(|(s, dest)| stream_video(api, &s.stream_url_path, dest)),
+        )
+        .await;
+        // throw RetryableError::Fail if any
+        stream_results
+            .iter()
+            .copied()
+            .find(|sr| matches!(sr, Err(RetryableError::Fail(_))))
+            .transpose()?;
+        // throw RetryableError if any
+        stream_results
+            .iter()
+            .copied()
+            .find(|sr| matches!(sr, Err(_)))
+            .transpose()?;
+
+        // now we know that all downloads succeeded
+
+        // mux the temp files
+        let temp_stream_dests_ref = temp_stream_dests.as_slice();
         stream_impl(
             api,
             move |cmd| {
-                let cmd = streams.iter().fold(cmd, move |cmd, s| {
-                    cmd.arg("-itsoffset")
-                        .arg(s.offset_seconds.to_string())
-                        .arg("-i")
-                        .arg(&s.stream_url_path)
-                });
-                streams
-                    .iter()
-                    .enumerate()
-                    .fold(cmd, move |cmd, (i, _)| cmd.arg("-map").arg(i.to_string()))
+                let cmd = streams.iter().zip(temp_stream_dests_ref.iter()).fold(
+                    cmd,
+                    move |cmd, (s, tsd)| {
+                        cmd.arg("-itsoffset")
+                            .arg(s.offset_seconds.to_string())
+                            .arg("-i")
+                            .arg(tsd.as_path())
+                    },
+                );
+                (0..streams.len()).fold(cmd, move |cmd, i| cmd.arg("-map").arg(i.to_string()))
             },
             temp_destination,
         )
-        .await
+        .await?;
+
+        // delete the temp files (but silence the error if not possible)
+        futures_util::future::join_all(temp_stream_dests.into_iter().map(tokio::fs::remove_file))
+            .await;
+
+        Ok(())
     }
+}
+
+fn make_temp_stream_file_name(name: &Path, index: usize) -> PathBuf {
+    let old_filename = name.file_name().expect("Path needs file name");
+    let prepend = OsStr::new("~!");
+    let index_string = index.to_string();
+    let after_prepend = prepend;
+    let index_osstr = OsStr::new(&index_string);
+    let mut new_filename = OsString::with_capacity(
+        prepend.len() + index_osstr.len() + after_prepend.len() + old_filename.len(),
+    );
+    new_filename.push(prepend);
+    new_filename.push(index_osstr);
+    new_filename.push(after_prepend);
+    new_filename.push(old_filename);
+    let mut res = name.to_path_buf();
+    res.set_file_name(new_filename);
+    res
 }
 
 async fn stream_impl(

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -11,18 +11,68 @@ pub async fn stream_video(
     stream_url_path: &str,
     temp_destination: &Path,
 ) -> RetryableResult<()> {
-    let success = Command::new(&api.ffmpeg_path)
-        .arg("-y") // flag to overwrite output file without prompting
-        .arg("-i")
-        .arg(stream_url_path)
-        .arg("-c")
-        .arg("copy")
-        .arg(temp_destination.as_os_str())
-        .output()
+    stream_impl(
+        api,
+        move |cmd| cmd.arg("-i").arg(stream_url_path),
+        temp_destination,
+    )
+    .await
+}
+
+#[derive(Debug, Clone)]
+pub struct StreamSpec {
+    pub stream_url_path: String,
+    pub offset_seconds: f64,
+}
+
+/// Uses ffmpeg to stream multiple m3u8 video files and mux them together.
+/// If there are multiple streams, ffmpeg automatically chooses the one with highest quality,
+/// which is what we want.
+pub async fn stream_and_mux_videos(
+    api: &Api,
+    streams: &[StreamSpec],
+    temp_destination: &Path,
+) -> RetryableResult<()> {
+    if streams.len() == 1 {
+        // if there's only one video, we should ignore the offset
+        stream_video(api, &streams[0].stream_url_path, temp_destination).await
+    } else {
+        stream_impl(
+            api,
+            move |cmd| {
+                let cmd = streams.iter().fold(cmd, move |cmd, s| {
+                    cmd.arg("-itsoffset")
+                        .arg(s.offset_seconds.to_string())
+                        .arg("-i")
+                        .arg(&s.stream_url_path)
+                });
+                streams
+                    .iter()
+                    .enumerate()
+                    .fold(cmd, move |cmd, (i, _)| cmd.arg("-map").arg(i.to_string()))
+            },
+            temp_destination,
+        )
         .await
-        .map_err(|_| RetryableError::Fail("Failed to start ffmpeg"))?
-        .status
-        .success();
+    }
+}
+
+async fn stream_impl(
+    api: &Api,
+    input_args_appender: impl FnOnce(&mut Command) -> &mut Command,
+    temp_destination: &Path,
+) -> RetryableResult<()> {
+    let success = input_args_appender(
+        Command::new(&api.ffmpeg_path).arg("-y"), // flag to overwrite output file without prompting
+    )
+    .arg("-c")
+    .arg("copy")
+    .arg(temp_destination.as_os_str())
+    .output()
+    .await
+    .map_err(|_| RetryableError::Fail("Failed to start ffmpeg"))?
+    .status
+    .success();
     if success {
         Ok(())
     } else {

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -1,0 +1,31 @@
+use crate::resource::{RetryableError, RetryableResult};
+use crate::Api;
+use std::path::Path;
+use tokio::process::Command;
+
+/// Uses ffmpeg to stream a given m3u8 video file.
+/// If there are multiple streams, ffmpeg automatically chooses the one with highest quality,
+/// which is what we want.
+pub async fn stream_video(
+    api: &Api,
+    stream_url_path: &str,
+    temp_destination: &Path,
+) -> RetryableResult<()> {
+    let success = Command::new(&api.ffmpeg_path)
+        .arg("-y") // flag to overwrite output file without prompting
+        .arg("-i")
+        .arg(stream_url_path)
+        .arg("-c")
+        .arg("copy")
+        .arg(temp_destination.as_os_str())
+        .output()
+        .await
+        .map_err(|_| RetryableError::Fail("Failed to start ffmpeg"))?
+        .status
+        .success();
+    if success {
+        Ok(())
+    } else {
+        Err(RetryableError::Retry("ffmpeg returned nonzero exit code"))
+    }
+}


### PR DESCRIPTION
This PR uses ffmpeg to stream external multimedia and weblecture videos from Panopto, since there is no longer a direct download link.

Resolves #657.