### PR TITLE
Rename files with multiple extensions (e.g. .tar.gz) correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,9 +158,13 @@ where
             .build()
             .map_err(|_| "Failed to build request")?;
 
-        let res = client.execute(request).await.map_err(|_| "HTTP error");
-        if let Ok(res) = res {
-            break res;
+        match client.execute(request).await {
+            Ok(res) => {
+                break res;
+            }
+            Err(e) => {
+                println!("Error in infinite retry HTTP for {} {}: {}", method, url, e);
+            }
         }
     };
     Ok(res)


### PR DESCRIPTION
Previously, we get into an infinite loop when using the rename updated files mode and the file being updated has multiple extensions (c.f. CS2106 lab files having .tar.gz extension).