### PR TITLE
Add include and exclude options to filter files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,9 +110,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -307,6 +316,7 @@ dependencies = [
  "env_logger",
  "filetime",
  "futures-util",
+ "globset",
  "htmlescape",
  "rand 0.8.4",
  "regex",
@@ -460,6 +470,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,9 +566,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
@@ -555,9 +578,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -649,9 +672,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -845,9 +868,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.70"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg",
  "cc",
@@ -1003,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "psl-types"
-version = "2.0.7"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b398073e7cdd6f05934389a8f5961e3aabfa66675b6f440df4e2c793d51a4f"
+checksum = "01e985332847890fc9ff26986900c036c8b3fde8da6a31d8ca315cc116405b8c"
 
 [[package]]
 name = "publicsuffix"
@@ -1366,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1646,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1661,9 +1684,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1681,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["cli"]
 
 [features]
 default = []
-cli = ["clap", "rpassword"]
+cli = ["clap", "globset", "rpassword"]
 with-env-logger = ['env_logger']
 
 [profile.release]
@@ -36,6 +36,7 @@ clap = { version = "2.33", optional = true }
 env_logger = { version = "0.9", optional = true }
 filetime = "0.2"
 futures-util = "0.3"
+globset = { version = "0.4", optional = true }
 htmlescape = "0.3"
 rand = "0.8"
 regex = "1.5"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -490,7 +490,7 @@ async fn main() -> Result<()> {
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1)
-                .help("Glob of files to include. Takes precedence over exclude"),
+                .help("Glob of file paths to include. Takes precedence over exclude"),
         )
         .get_matches();
     let credential_file = matches

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use clap::{App, Arg};
 use futures_util::{future, stream, StreamExt};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
 use fluminurs::conferencing::ZoomRecording;
@@ -259,6 +260,33 @@ async fn load_modules_conferences(api: &Api, modules: &[Module]) -> Result<Vec<Z
     Ok(zoom_recordings)
 }
 
+fn filter_resources<T: Resource>(
+    resources: Vec<T>,
+    include_globset: &Option<GlobSet>,
+    exclude_globset: &Option<GlobSet>,
+) -> Vec<T> {
+    if include_globset.is_none() && exclude_globset.is_none() {
+        resources
+    } else {
+        resources
+            .into_iter()
+            .filter(|resource| {
+                let excluded = exclude_globset
+                    .as_ref()
+                    .map(|glob_set| glob_set.is_match(resource.path()))
+                    .unwrap_or(false);
+                let included = include_globset
+                    .as_ref()
+                    .map(|glob_set| glob_set.is_match(resource.path()))
+                    .unwrap_or(false);
+
+                // `include` takes precedence over `exclude`
+                !excluded || included
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
 fn list_resources<T: Resource>(resources: &[T]) {
     for resource in resources {
         println!("{}", resource.path().display())
@@ -448,6 +476,22 @@ async fn main() -> Result<()> {
                 .default_value("ffmpeg")
                 .help("Path to ffmpeg executable for downloading multimedia"),
         )
+        .arg(
+            Arg::with_name("exclude")
+                .long("exclude")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1)
+                .help("Glob of file paths to exclude"),
+        )
+        .arg(
+            Arg::with_name("include")
+                .long("include")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1)
+                .help("Glob of files to include. Takes precedence over exclude"),
+        )
         .get_matches();
     let credential_file = matches
         .value_of("credential-file")
@@ -511,6 +555,20 @@ async fn main() -> Result<()> {
     let specified_modules = matches
         .values_of("modules")
         .map(|it| it.collect::<Vec<&str>>());
+    let exclude_globset = matches.values_of("exclude").and_then(|values| {
+        let mut builder = GlobSetBuilder::new();
+        for glob in values {
+            builder.add(Glob::new(glob).ok()?);
+        }
+        builder.build().ok()
+    });
+    let include_globset = matches.values_of("include").and_then(|values| {
+        let mut builder = GlobSetBuilder::new();
+        for glob in values {
+            builder.add(Glob::new(glob).ok()?);
+        }
+        builder.build().ok()
+    });
 
     let (username, password) =
         get_credentials(&credential_file).expect("Unable to get credentials");
@@ -567,6 +625,7 @@ async fn main() -> Result<()> {
             regularize_uploadable,
         )
         .await?;
+        let module_file = filter_resources(module_file, &include_globset, &exclude_globset);
 
         if do_files {
             list_resources(&module_file);
@@ -580,6 +639,16 @@ async fn main() -> Result<()> {
     if do_multimedia || multimedia_download_destination.is_some() {
         let (module_internal_multimedia, module_external_multimedia) =
             load_modules_multimedia(&api, &modules).await?;
+        let module_internal_multimedia = filter_resources(
+            module_internal_multimedia,
+            &include_globset,
+            &exclude_globset,
+        );
+        let module_external_multimedia = filter_resources(
+            module_external_multimedia,
+            &include_globset,
+            &exclude_globset,
+        );
 
         if do_multimedia {
             list_resources(&module_internal_multimedia);
@@ -614,6 +683,8 @@ async fn main() -> Result<()> {
 
     if do_weblectures || weblectures_download_destination.is_some() {
         let module_weblectures = load_modules_weblectures(&api, &modules).await?;
+        let module_weblectures =
+            filter_resources(module_weblectures, &include_globset, &exclude_globset);
 
         if do_weblectures {
             list_resources(&module_weblectures);
@@ -626,6 +697,8 @@ async fn main() -> Result<()> {
 
     if do_conferences || conferences_download_destination.is_some() {
         let module_conferences = load_modules_conferences(&api, &modules).await?;
+        let module_conferences =
+            filter_resources(module_conferences, &include_globset, &exclude_globset);
 
         if do_conferences {
             list_resources(&module_conferences);


### PR DESCRIPTION
Both options can accept multiple globs, which will be matched against each file path. All files will be included by default, except those which match any of the `exclude` globs. However, files which match the `include` globs will always be included, i.e., `include` takes precedence over `exclude`.

This makes use of the `globset` crate: https://docs.rs/globset.

Closes #664.
